### PR TITLE
Fix hmac_sha

### DIFF
--- a/app/src/main/java/org/cry/otp/TOTP.java
+++ b/app/src/main/java/org/cry/otp/TOTP.java
@@ -17,95 +17,15 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * Implementation of TOTP: Time-Based One-Time Password Algorithm derived from RFC 6238.
  * Copyright (c) 2011 IETF Trust and the persons identified as the document authors.
- * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, is permitted
- * pursuant to, and subject to the license terms contained in the Simplified BSD License set forth
- * in Section 4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
- * (http://trustee.ietf.org/license-info)
- * This code was derived from IETF RFC 6238. Please reproduce this note if possible.
- * @author Johan Rydell, PortWise, Inc., Chris Miceli, Michael Miceli
- */
-public class TOTP {
-
-    private TOTP() {
 private static byte[] hmac_sha(String crypto, byte[] keyBytes, byte[] text) {
-    try {
-        Mac hmac = Mac.getInstance(crypto);
-        SecretKeySpec macKey = new SecretKeySpec(keyBytes, "RAW");
-        hmac.init(macKey);
-
-        // Acquire the lock on the hmac object before returning the result
-        synchronized (hmac) {
+    synchronized (hmac) {
+        try {
+            Mac hmac = Mac.getInstance(crypto);
+            SecretKeySpec macKey = new SecretKeySpec(keyBytes, "RAW");
+            hmac.init(macKey);
             return hmac.doFinal(text);
+        } catch (GeneralSecurityException gse) {
+            throw new UndeclaredThrowableException(gse);
         }
-    } catch (GeneralSecurityException gse) {
-        throw new UndeclaredThrowableException(gse);
-    }
-}
-}
-
-    /**
-     * This method converts HEX string to Byte[]
-     *
-     * @param hex the HEX string
-     * @return A byte array
-     */
-    private static byte[] hexStr2Bytes(String hex) {
-        // Adding one byte to get the right conversion
-        // values starting with "0" can be converted
-        byte[] bArray = new BigInteger("10" + hex, 16).toByteArray();
-
-        // Copy all the REAL bytes, not the "first"
-        byte[] ret = new byte[bArray.length - 1];
-        for (int i = 0; i < ret.length; i++) {
-             ret[i] = bArray[i+1];
-        }
-
-        return ret;
-    }
-
-    public static String gen(String key, long timeInSeconds, int returnDigits, int shaType, int timeInterval) {
-        long T0 = 0;
-
-        long T = (timeInSeconds - T0) / (long) timeInterval;
-
-        // represent number of time intervals as 0-left padded hex in uppercase
-        String time = String.format("%016X", T);
-
-        StringBuilder result;
-        byte[] hash;
-
-        // Get the HEX in a Byte[]
-        byte[] msg = hexStr2Bytes(time);
-
-        byte[] k = hexStr2Bytes(key);
-
-        String crypto;
-        if (shaType == 0) {
-            crypto = "HmacSHA1";
-        } else if (shaType == 1) {
-            crypto = "HmacSHA256";
-        } else {
-            // sha 512
-            crypto = "HmacSHA512";
-        }
-
-        hash = hmac_sha(crypto, k, msg);
-
-        // put selected bytes into result int
-        int offset = hash[hash.length - 1] & 0xf;
-
-        int binary = ((hash[offset] & 0x7f) << 24)
-                | ((hash[offset + 1] & 0xff) << 16)
-                | ((hash[offset + 2] & 0xff) << 8) | (hash[offset + 3] & 0xff);
-
-        int otp = binary % (int) (Math.pow(10, returnDigits));
-
-        result = new StringBuilder(Integer.toString(otp));
-        while (result.length() < returnDigits) {
-            result.insert(0, "0");
-        }
-
-        return result.toString();
     }
 }

--- a/app/src/main/java/org/cry/otp/TOTP.java
+++ b/app/src/main/java/org/cry/otp/TOTP.java
@@ -39,17 +39,19 @@ public class TOTP {
      * @param keyBytes the bytes to use for the HMAC key
      * @param text     the message or text to be authenticated.
      */
-    private static byte[] hmac_sha(String crypto, byte[] keyBytes, byte[] text) {
-        try {
-            Mac hmac;
-            hmac = Mac.getInstance(crypto);
-            SecretKeySpec macKey = new SecretKeySpec(keyBytes, "RAW");
-            hmac.init(macKey);
+private static byte[] hmac_sha(String crypto, byte[] keyBytes, byte[] text) {
+    try {
+        Mac hmac;
+        hmac = Mac.getInstance(crypto);
+        SecretKeySpec macKey = new SecretKeySpec(keyBytes, "RAW");
+        hmac.init(macKey);
+        synchronized (hmac) {
             return hmac.doFinal(text);
-        } catch (GeneralSecurityException gse) {
-            throw new UndeclaredThrowableException(gse);
         }
+    } catch (GeneralSecurityException gse) {
+        throw new UndeclaredThrowableException(gse);
     }
+}
 
     /**
      * This method converts HEX string to Byte[]

--- a/app/src/main/java/org/cry/otp/TOTP.java
+++ b/app/src/main/java/org/cry/otp/TOTP.java
@@ -28,29 +28,20 @@ import javax.crypto.spec.SecretKeySpec;
 public class TOTP {
 
     private TOTP() {
-    }
-
-    /**
-     * This method uses the JCE to provide the crypto algorithm. HMAC computes a
-     * Hashed Message Authentication Code with the crypto hash algorithm as a
-     * parameter.
-     *
-     * @param crypto   the crypto algorithm (HmacSHA1, HmacSHA256, HmacSHA512)
-     * @param keyBytes the bytes to use for the HMAC key
-     * @param text     the message or text to be authenticated.
-     */
 private static byte[] hmac_sha(String crypto, byte[] keyBytes, byte[] text) {
     try {
-        Mac hmac;
-        hmac = Mac.getInstance(crypto);
+        Mac hmac = Mac.getInstance(crypto);
         SecretKeySpec macKey = new SecretKeySpec(keyBytes, "RAW");
         hmac.init(macKey);
+
+        // Acquire the lock on the hmac object before returning the result
         synchronized (hmac) {
             return hmac.doFinal(text);
         }
     } catch (GeneralSecurityException gse) {
         throw new UndeclaredThrowableException(gse);
     }
+}
 }
 
     /**


### PR DESCRIPTION
# Fix: `hmac_sha`

## Explanation

By default, Java's `Mac` objects are thread-safe, meaning that they can be used concurrently by multiple threads without the risk of interference or corruption. However, in this case, the `hmac_sha` method is not properly synchronizing on the `Mac` object before returning the result. This can lead t

---

## Modified Method

| Property | Value |
|---|---|
| Method | `hmac_sha` |
| Class | `org.cry.otp.TOTP` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/org.cry.otp_31.apk/app/src/main/java/org/cry/otp/TOTP.java` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/org.cry.otp_31.apk/app/src/main/java/org/cry/otp/TOTP.java
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline